### PR TITLE
replace plotly requirement with chart_studio in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,6 @@ setup(
         'numpy',
         'pandas',
         'pandas_datareader',
-        'plotly'
+        'chart_studio'
     ]
 )


### PR DESCRIPTION
Thanks for sharing the import fixes for plotly -> chart_studio.  This additional minor change is needed to automatically install chart_studio instead of plotly when you do a pip install